### PR TITLE
fix(ci): correct PR artifact installation instructions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,23 +284,6 @@ jobs:
           echo "name=$NAME" >> $GITHUB_OUTPUT
           echo "size=$SIZE" >> $GITHUB_OUTPUT
 
-      - name: Create test matrix summary
-        id: matrix
-        run: |
-          echo "## Test Results Summary" > summary.md
-          echo "" >> summary.md
-          echo "| Platform | Node 22 |" >> summary.md
-          echo "|----------|---------|" >> summary.md
-          echo "| Linux x64 | ✅ |" >> summary.md
-          echo "| macOS ARM64 | ✅ |" >> summary.md
-          echo "| macOS x64 | ✅ |" >> summary.md
-          echo "" >> summary.md
-          echo "Integration tests: Run locally (not in CI for reliability)" >> summary.md
-
-          echo "summary<<EOF" >> $GITHUB_OUTPUT
-          cat summary.md >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
-
       - uses: actions/github-script@v7
         with:
           script: |
@@ -311,14 +294,19 @@ jobs:
             **Platforms**: Linux (x64/ARM64), macOS (x64/ARM64)
             **Node.js**: 22
 
-            ${{ steps.matrix.outputs.summary }}
-
             #### Test Installation
 
             \`\`\`bash
-            # Download and test this PR's build
-            curl -L -o mcpadre.tgz "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/npm-package"
-            npm install -g ./mcpadre.tgz
+            # Download the npm-package artifact (zip file containing the tarball)
+            curl -L -o npm-package.zip "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/npm-package"
+
+            # Extract the tarball from the zip
+            unzip npm-package.zip
+
+            # Install the specific tarball globally
+            npm install -g ${{ steps.package.outputs.name }}
+
+            # Verify installation
             mcpadre --version
             \`\`\`
 


### PR DESCRIPTION
- Remove hardcoded test status table that always showed checkmarks
- Fix artifact download instructions to use actual GitHub artifact zip format
- Provide accurate curl/unzip/install steps for testing PR builds
- Use computed tarball filename from package info step

The comment only appears when all tests pass due to job dependencies, so no need to redundantly report test status.

## Description

Brief description of changes and their purpose.

## Related Issues

- Fixes #
- Addresses #

## Changes

-
-

## Testing

- [x] **Integration tests run locally and pass** (required - integration tests don't run in CI yet)
- [x] Unit tests pass (`pnpm test`)
- [x]Type checking passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)

## Additional Notes

Any edge cases, breaking changes, or special considerations.
