### PR TITLE
fix: user directory path handling for all server operations

### DIFF
--- a/packages/cli/src/cli/outdated.ts
+++ b/packages/cli/src/cli/outdated.ts
@@ -164,7 +164,8 @@ async function runOutdatedLogic(
       workingDir,
       docker,
       CLI_LOGGER,
-      checkOptions
+      checkOptions,
+      mode
     );
 
     // Apply filtering if requested

--- a/packages/cli/src/installer/discovery/server-detector.ts
+++ b/packages/cli/src/installer/discovery/server-detector.ts
@@ -202,19 +202,23 @@ export function classifyServers(
 /**
  * Analyzes server directories on disk to find orphaned directories
  *
- * @param projectDir Absolute path to the project directory
+ * @param projectDir Absolute path to the project directory (or user directory in user mode)
  * @param mcpadreServerNames Set of server names currently defined in mcpadre.yaml
+ * @param isUserMode Whether this is for user-level configuration
  * @returns Analysis of server directories
  */
 export async function analyzeServerDirectories(
   projectDir: string,
-  mcpadreServerNames: Set<string>
+  mcpadreServerNames: Set<string>,
+  isUserMode = false
 ): Promise<ServerDirectoryAnalysis> {
   const result: ServerDirectoryAnalysis = {
     orphanedDirectories: [],
   };
 
-  const serversDir = join(projectDir, ".mcpadre", "servers");
+  const serversDir = isUserMode
+    ? join(projectDir, "servers")
+    : join(projectDir, ".mcpadre", "servers");
 
   try {
     const entries = await readdir(serversDir, { withFileTypes: true });
@@ -225,7 +229,7 @@ export async function analyzeServerDirectories(
       }
     }
   } catch (error) {
-    // If .mcpadre/servers doesn't exist or can't be read, that's fine
+    // If servers directory doesn't exist or can't be read, that's fine
     // Just return empty analysis
     if (error instanceof Error && "code" in error && error.code !== "ENOENT") {
       // Re-throw non-ENOENT errors (permission issues, etc.)

--- a/packages/cli/src/installer/installer.ts
+++ b/packages/cli/src/installer/installer.ts
@@ -325,7 +325,8 @@ export async function installForHost(
   // Analyze server directories on disk
   const directoryAnalysis = await analyzeServerDirectories(
     projectDir,
-    new Set(Object.keys(config.mcpServers))
+    new Set(Object.keys(config.mcpServers)),
+    false // Project mode
   );
 
   // Log external servers (INFO level)
@@ -607,6 +608,7 @@ export async function installForUserHost(
             container: serverConfig.container,
             projectDir: userDir, // Use user directory as project directory
             logger,
+            isUserMode: true, // Enable user mode for container manager
           });
 
           if (installResult.imagePulled) {
@@ -733,7 +735,8 @@ export async function installForUserHost(
   // Analyze server directories on disk (in user directory)
   const directoryAnalysis = await analyzeServerDirectories(
     userDir,
-    new Set(Object.keys(config.mcpServers))
+    new Set(Object.keys(config.mcpServers)),
+    true // User mode
   );
 
   // Log external servers (INFO level)

--- a/packages/cli/src/installer/managers/node-manager.ts
+++ b/packages/cli/src/installer/managers/node-manager.ts
@@ -27,7 +27,7 @@ export interface NodeInstallOptions {
   node: NodeOptionsV1;
   /** Base directory where .mcpadre is located */
   projectDir: string;
-  /** Server directory path (.mcpadre/servers/$serverName) */
+  /** Server directory path (project: .mcpadre/servers/$serverName, user: servers/$serverName) */
   serverDir: string;
   /** Logger instance */
   logger: Logger;

--- a/packages/cli/src/installer/managers/python-manager.ts
+++ b/packages/cli/src/installer/managers/python-manager.ts
@@ -27,7 +27,7 @@ export interface PythonInstallOptions {
   python: PythonOptionsV1;
   /** Base directory where .mcpadre is located */
   projectDir: string;
-  /** Server directory path (.mcpadre/servers/$serverName) */
+  /** Server directory path (project: .mcpadre/servers/$serverName, user: servers/$serverName) */
   serverDir: string;
   /** Logger instance */
   logger: Logger;

--- a/packages/cli/src/integration-tests/cli/simple-user-mode-debug.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli/simple-user-mode-debug.integration.test.ts
@@ -1,0 +1,45 @@
+// pattern: Imperative Shell
+// Simplified test to debug user mode CLI interaction
+
+import { describe, expect, it } from "vitest";
+
+import { type SpawnFunction, withProcess } from "../helpers/spawn-cli-v2.js";
+import {
+  createTempUserDir,
+  runUserModeCommand,
+} from "../helpers/user-mode-utils.js";
+
+describe("Simple User Mode Debug", () => {
+  it(
+    "should run basic --help with --user-dir",
+    withProcess(async (spawn: SpawnFunction) => {
+      const tempUserDir = await createTempUserDir();
+
+      // Just test that --user-dir + --help works without hanging
+      const result = await spawn(["--user-dir", tempUserDir, "--help"], {
+        buffer: true,
+      });
+      expect(result.exitCode).toBe(0);
+    })
+  );
+
+  it(
+    "should handle install --user with missing config gracefully",
+    withProcess(async (spawn: SpawnFunction) => {
+      const tempUserDir = await createTempUserDir();
+      const tempProjectDir = await createTempUserDir(); // Use as project dir
+
+      // This should fail gracefully, not hang
+      const result = await runUserModeCommand(
+        spawn,
+        tempUserDir,
+        tempProjectDir,
+        ["install", "--user"]
+      );
+
+      // Should fail with config error, not hang
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("config");
+    })
+  );
+});

--- a/packages/cli/src/integration-tests/cli/user-mode-paths.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli/user-mode-paths.integration.test.ts
@@ -1,0 +1,116 @@
+// pattern: Imperative Shell
+// Integration tests for user mode directory path handling (without Docker operations)
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { type SpawnFunction, withProcess } from "../helpers/spawn-cli-v2.js";
+import {
+  cleanupTestEnvironment,
+  createTempProjectDir,
+  createTempUserDir,
+  createUserConfig,
+  runUserModeCommand,
+  TEST_NODE_SERVER_CONFIG,
+} from "../helpers/user-mode-utils.js";
+
+describe("User Mode Path Integration Tests", () => {
+  let tempUserDir: string;
+  let tempProjectDir: string;
+  let cleanupPaths: string[];
+
+  beforeEach(async () => {
+    tempUserDir = await createTempUserDir();
+    tempProjectDir = await createTempProjectDir();
+    cleanupPaths = [tempUserDir, tempProjectDir];
+  });
+
+  afterEach(async () => {
+    await cleanupTestEnvironment(cleanupPaths);
+  });
+
+  describe("Node Server User Mode", () => {
+    it(
+      "should attempt to install node server in user directory",
+      withProcess(async (spawn: SpawnFunction) => {
+        // Create user config with node server
+        await createUserConfig(tempUserDir, TEST_NODE_SERVER_CONFIG);
+
+        // Run install --user (should attempt npm install)
+        const result = await runUserModeCommand(
+          spawn,
+          tempUserDir,
+          tempProjectDir,
+          ["install", "--user"]
+        );
+
+        // Should succeed in user mode
+        expect(result.exitCode).toBe(0);
+
+        // Should indicate it's working in user mode
+        const output = result.stdout + result.stderr;
+        expect(output).toContain("user mode");
+      })
+    );
+
+    it(
+      "should load user config from user directory",
+      withProcess(async (spawn: SpawnFunction) => {
+        // Create user config
+        await createUserConfig(tempUserDir, TEST_NODE_SERVER_CONFIG);
+
+        // Any command that loads config should find the user config
+        const result = await runUserModeCommand(
+          spawn,
+          tempUserDir,
+          tempProjectDir,
+          ["install", "--user"] // This will fail but should load config first
+        );
+
+        // Should see evidence of config loading and user mode operation
+        const output = result.stdout + result.stderr;
+        expect(output).toContain("user mode");
+      })
+    );
+
+    it(
+      "should fail gracefully when user config is missing",
+      withProcess(async (spawn: SpawnFunction) => {
+        // Don't create any user config
+
+        // Run command that requires user config
+        const result = await runUserModeCommand(
+          spawn,
+          tempUserDir,
+          tempProjectDir,
+          ["install", "--user"]
+        );
+
+        // Should fail with config-related error
+        expect(result.exitCode).not.toBe(0);
+        expect(result.stderr).toContain("config");
+      })
+    );
+  });
+
+  describe("User Directory Path Verification", () => {
+    it(
+      "should respect --user-dir flag consistently",
+      withProcess(async (spawn: SpawnFunction) => {
+        // Create config in user directory
+        await createUserConfig(tempUserDir, TEST_NODE_SERVER_CONFIG);
+
+        // Run install with --user-dir
+        const installResult = await runUserModeCommand(
+          spawn,
+          tempUserDir,
+          tempProjectDir,
+          ["install", "--user"]
+        );
+
+        // Should load config and work in user mode
+        const output = installResult.stdout + installResult.stderr;
+        expect(output).toContain("user mode");
+      })
+    );
+  });
+});

--- a/packages/cli/src/integration-tests/helpers/user-mode-utils.ts
+++ b/packages/cli/src/integration-tests/helpers/user-mode-utils.ts
@@ -1,0 +1,356 @@
+// pattern: Imperative Shell
+// Integration test utilities for user mode functionality
+
+import { mkdir, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import YAML from "yaml";
+
+import type { SettingsUser } from "../../config/types/index.js";
+import type { SpawnFunction } from "./spawn-cli-v2.js";
+
+/**
+ * Creates a temporary user directory for testing user mode functionality
+ */
+export async function createTempUserDir(): Promise<string> {
+  const userDir = join(
+    tmpdir(),
+    `mcpadre-user-test-${Date.now()}-${Math.random().toString(36).substring(2)}`
+  );
+  await mkdir(userDir, { recursive: true });
+  return userDir;
+}
+
+/**
+ * Creates a temporary project directory for testing isolation
+ */
+export async function createTempProjectDir(): Promise<string> {
+  const projectDir = join(
+    tmpdir(),
+    `mcpadre-project-test-${Date.now()}-${Math.random().toString(36).substring(2)}`
+  );
+  await mkdir(projectDir, { recursive: true });
+  return projectDir;
+}
+
+/**
+ * Creates a user configuration file in the specified user directory
+ */
+export async function createUserConfig(
+  userDir: string,
+  config: SettingsUser
+): Promise<string> {
+  const configPath = join(userDir, "mcpadre.yaml");
+  const yamlContent = YAML.stringify(config);
+  await writeFile(configPath, yamlContent, "utf8");
+  return configPath;
+}
+
+/**
+ * Creates a complete temporary user environment with config
+ */
+export async function createTempUserEnvironment(
+  config: SettingsUser
+): Promise<{
+  userDir: string;
+  configPath: string;
+  cleanup: () => Promise<void>;
+}> {
+  const userDir = await createTempUserDir();
+  const configPath = await createUserConfig(userDir, config);
+
+  const cleanup = async (): Promise<void> => {
+    await rm(userDir, { recursive: true, force: true });
+  };
+
+  return { userDir, configPath, cleanup };
+}
+
+/**
+ * Returns spawn options for user mode commands with --user-dir flag
+ */
+export function getUserModeSpawnArgs(
+  userDir: string,
+  baseArgs: string[]
+): string[] {
+  return ["--user-dir", userDir, ...baseArgs];
+}
+
+/**
+ * Test configuration templates for common scenarios
+ */
+export const TEST_CONTAINER_SERVER_CONFIG: SettingsUser = {
+  version: 1,
+  mcpServers: {
+    "test-container": {
+      container: {
+        image: "alpine",
+        tag: "latest",
+      },
+    },
+  },
+  hosts: {
+    "claude-code": true,
+  },
+};
+
+export const TEST_NODE_SERVER_CONFIG: SettingsUser = {
+  version: 1,
+  mcpServers: {
+    "test-node": {
+      node: {
+        package: "@modelcontextprotocol/server-filesystem",
+        version: "0.6.0",
+      },
+    },
+  },
+  hosts: {
+    "claude-code": true,
+  },
+};
+
+export const TEST_PYTHON_SERVER_CONFIG: SettingsUser = {
+  version: 1,
+  mcpServers: {
+    "test-python": {
+      python: {
+        package: "mcp-server-git",
+        version: "0.6.0",
+      },
+    },
+  },
+  hosts: {
+    "claude-code": true,
+  },
+};
+
+export const TEST_MULTI_SERVER_CONFIG: SettingsUser = {
+  version: 1,
+  mcpServers: {
+    "container-server": {
+      container: {
+        image: "alpine",
+        tag: "latest",
+      },
+    },
+    "node-server": {
+      node: {
+        package: "@modelcontextprotocol/server-filesystem",
+        version: "0.6.0",
+      },
+    },
+    "python-server": {
+      python: {
+        package: "mcp-server-git",
+        version: "0.6.0",
+      },
+    },
+  },
+  hosts: {
+    "claude-code": true,
+  },
+};
+
+/**
+ * Verifies that files exist in user directory structure
+ */
+export async function verifyUserModeFiles(
+  userDir: string,
+  serverName: string,
+  expectedFiles: string[]
+): Promise<boolean> {
+  const fs = await import("fs/promises");
+  const serverPath = join(userDir, "servers", serverName);
+
+  try {
+    // Check if server directory exists
+    await fs.access(serverPath);
+
+    // Check if all expected files exist
+    for (const fileName of expectedFiles) {
+      const filePath = join(serverPath, fileName);
+      await fs.access(filePath);
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verifies that files do NOT exist in project directory structure
+ */
+export async function verifyProjectModeFilesAbsent(
+  projectDir: string,
+  serverName: string,
+  fileNames: string[]
+): Promise<boolean> {
+  const fs = await import("fs/promises");
+  const serverPath = join(projectDir, ".mcpadre", "servers", serverName);
+
+  try {
+    // Check if any of the files exist (they shouldn't)
+    for (const fileName of fileNames) {
+      const filePath = join(serverPath, fileName);
+      try {
+        await fs.access(filePath);
+        return false; // File exists when it shouldn't
+      } catch {
+        // File doesn't exist, which is what we want
+      }
+    }
+
+    return true; // None of the files exist (correct)
+  } catch {
+    return true; // Directory doesn't exist, which is fine
+  }
+}
+
+/**
+ * Creates a test configuration with specified server names for testing orphans
+ */
+export function createConfigWithServers(serverNames: string[]): SettingsUser {
+  const mcpServers: SettingsUser["mcpServers"] = {};
+
+  serverNames.forEach((name, index) => {
+    // Alternate between different server types for variety
+    switch (index % 3) {
+      case 0:
+        mcpServers[name] = {
+          container: { image: "alpine", tag: "latest" },
+        };
+        break;
+      case 1:
+        mcpServers[name] = {
+          node: { package: "test-package", version: "1.0.0" },
+        };
+        break;
+      case 2:
+        mcpServers[name] = {
+          python: { package: "test-package", version: "1.0.0" },
+        };
+        break;
+    }
+  });
+
+  return {
+    version: 1,
+    mcpServers,
+    hosts: {
+      "claude-code": true,
+    },
+  };
+}
+
+/**
+ * Helper to run user mode CLI commands with proper --user-dir flag
+ */
+export async function runUserModeCommand(
+  spawn: SpawnFunction,
+  userDir: string,
+  projectDir: string,
+  command: string[],
+  options: {
+    buffer?: boolean;
+  } = {}
+): Promise<{
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const args = getUserModeSpawnArgs(userDir, command);
+
+  const result = await spawn(args, {
+    cwd: projectDir,
+    buffer: options.buffer ?? true,
+  });
+
+  return {
+    exitCode: result.exitCode ?? 0,
+    stdout: typeof result.stdout === "string" ? result.stdout : "",
+    stderr: typeof result.stderr === "string" ? result.stderr : "",
+  };
+}
+
+/**
+ * Waits for Docker to be available (for container tests)
+ */
+export async function waitForDocker(timeoutMs = 5000): Promise<boolean> {
+  const { exec } = await import("child_process");
+  const { promisify } = await import("util");
+  const execAsync = promisify(exec);
+
+  try {
+    const start = Date.now();
+
+    while (Date.now() - start < timeoutMs) {
+      try {
+        await execAsync("docker version", { timeout: 1000 });
+        return true;
+      } catch {
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+    }
+
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Skips Docker-based tests if Docker is not available
+ */
+export function skipIfDockerUnavailable(): void {
+  // This function should be called in test setup to conditionally skip tests
+  // Implementation depends on the test framework's skip mechanism
+}
+
+/**
+ * Creates directories and files to simulate server installations
+ */
+export async function createMockServerInstallation(
+  baseDir: string,
+  serverName: string,
+  isUserMode: boolean,
+  files: { name: string; content: string }[] = []
+): Promise<string> {
+  const serverDir = isUserMode
+    ? join(baseDir, "servers", serverName)
+    : join(baseDir, ".mcpadre", "servers", serverName);
+
+  await mkdir(serverDir, { recursive: true });
+
+  // Create default files if none specified
+  if (files.length === 0) {
+    files = [
+      { name: "package.json", content: "{}" },
+      {
+        name: "container.lock",
+        content: JSON.stringify({ digest: "sha256:test" }),
+      },
+    ];
+  }
+
+  for (const file of files) {
+    await writeFile(join(serverDir, file.name), file.content);
+  }
+
+  return serverDir;
+}
+
+/**
+ * Cleanup helper for test environments
+ */
+export async function cleanupTestEnvironment(paths: string[]): Promise<void> {
+  await Promise.all(
+    paths.map(async path => {
+      try {
+        await rm(path, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    })
+  );
+}


### PR DESCRIPTION
- Fix ContainerManager to use dynamic server directory paths based on mode
- Fix installer to pass isUserMode parameter to all manager operations
- Fix outdated checker to load user config and use correct paths in user mode
- Fix server detector to analyze directories based on operation mode
- Fix upgrader to respect user mode path conventions
- Add comprehensive integration tests for user mode functionality
- Add user mode test utilities with proper cleanup and isolation

Resolves issues where --user flag operations were using hardcoded project paths instead of user directory paths, causing container locks and server installations to be mislocated.