### PR TITLE
Feature/interactive add

### DIFF
--- a/packages/cli/src/cli/_utils/registry-flow.ts
+++ b/packages/cli/src/cli/_utils/registry-flow.ts
@@ -101,7 +101,18 @@ export async function runRegistryServerAddFlow(
             return { serverName: "", serverConfig: {}, cancelled: true };
           }
 
-          if (result.action === "continue" && result.value) {
+          if (result.action === "back") {
+            // First prompt - escape should exit entirely
+            await stateMachine.transition("escape");
+            return { serverName: "", serverConfig: {}, cancelled: true };
+          }
+
+          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- discriminated union check
+          if (result.action === "continue") {
+            if (!result.value) {
+              CLI_LOGGER.error("Registry type selection returned no value");
+              return { serverName: "", serverConfig: {}, cancelled: true };
+            }
             flowData.registryType = result.value;
             const transitionResult = await stateMachine.transition(
               "continue",

--- a/packages/cli/src/cli/server/registry-server-generator.test.ts
+++ b/packages/cli/src/cli/server/registry-server-generator.test.ts
@@ -26,24 +26,38 @@ describe("registry-server-generator", () => {
       });
     });
 
-    it("should throw error for unsupported registry types", () => {
-      expect(() => {
-        generateServerConfigFromRegistry({
-          serverName: "my-server",
-          registryType: "python" as any,
-          packageName: "requests",
-          version: "2.31.0",
-        });
-      }).toThrow("Python server generation not yet implemented");
+    it("should generate Python server config", () => {
+      const result = generateServerConfigFromRegistry({
+        serverName: "my-python-server",
+        registryType: "python",
+        packageName: "requests",
+        version: "2.31.0",
+      });
 
-      expect(() => {
-        generateServerConfigFromRegistry({
-          serverName: "my-server",
-          registryType: "container" as any,
-          packageName: "nginx",
-          version: "latest",
-        });
-      }).toThrow("Container server generation not yet implemented");
+      expect(result.serverName).toBe("my-python-server");
+      expect(result.serverConfig).toEqual({
+        python: {
+          package: "requests",
+          version: "2.31.0",
+        },
+      });
+    });
+
+    it("should generate Container server config", () => {
+      const result = generateServerConfigFromRegistry({
+        serverName: "my-container-server",
+        registryType: "container",
+        packageName: "nginx",
+        version: "latest",
+      });
+
+      expect(result.serverName).toBe("my-container-server");
+      expect(result.serverConfig).toEqual({
+        container: {
+          image: "nginx",
+          tag: "latest",
+        },
+      });
     });
 
     it("should throw error for completely invalid registry type", () => {

--- a/packages/cli/src/cli/server/registry-server-generator.ts
+++ b/packages/cli/src/cli/server/registry-server-generator.ts
@@ -1,6 +1,10 @@
 // pattern: Functional Core
 
-import type { NodeMcpServer } from "../../config/types/index.js";
+import type {
+  ContainerMcpServer,
+  NodeMcpServer,
+  PythonMcpServer,
+} from "../../config/types/index.js";
 import type { RegistryType } from "./registry/types.js";
 
 /**
@@ -24,7 +28,7 @@ export interface ServerGenerationResult {
   /** Server name */
   serverName: string;
   /** Generated server configuration */
-  serverConfig: NodeMcpServer;
+  serverConfig: NodeMcpServer | PythonMcpServer | ContainerMcpServer;
 }
 
 /**
@@ -38,10 +42,10 @@ export function generateServerConfigFromRegistry(
       return generateNodeServerConfig(data);
 
     case "python":
-      throw new Error("Python server generation not yet implemented");
+      return generatePythonServerConfig(data);
 
     case "container":
-      throw new Error("Container server generation not yet implemented");
+      return generateContainerServerConfig(data);
 
     default:
       throw new Error(`Unsupported registry type: ${data.registryType}`);
@@ -64,6 +68,44 @@ function generateNodeServerConfig(
   return {
     serverName: data.serverName,
     serverConfig: nodeConfig,
+  };
+}
+
+/**
+ * Generate Python MCP server configuration
+ */
+function generatePythonServerConfig(
+  data: RegistryServerData
+): ServerGenerationResult {
+  const pythonConfig: PythonMcpServer = {
+    python: {
+      package: data.packageName,
+      version: data.version,
+    },
+  };
+
+  return {
+    serverName: data.serverName,
+    serverConfig: pythonConfig,
+  };
+}
+
+/**
+ * Generate Container MCP server configuration
+ */
+function generateContainerServerConfig(
+  data: RegistryServerData
+): ServerGenerationResult {
+  const containerConfig: ContainerMcpServer = {
+    container: {
+      image: data.packageName,
+      tag: data.version,
+    },
+  };
+
+  return {
+    serverName: data.serverName,
+    serverConfig: containerConfig,
   };
 }
 

--- a/packages/cli/src/cli/server/registry/docker-adapter.test.ts
+++ b/packages/cli/src/cli/server/registry/docker-adapter.test.ts
@@ -1,0 +1,394 @@
+// pattern: Functional Core
+
+import { describe, expect, it } from "vitest";
+
+import {
+  type DockerHubTagsResponse,
+  parseDockerHubTagsResponse,
+  parseDockerImageName,
+  validateDockerImageName,
+} from "./docker-adapter.js";
+
+describe("parseDockerImageName", () => {
+  it("should handle official images without namespace", () => {
+    const result = parseDockerImageName("nginx");
+
+    expect(result.namespace).toBe("library");
+    expect(result.repository).toBe("nginx");
+    expect(result.fullName).toBe("library/nginx");
+  });
+
+  it("should handle user images with namespace", () => {
+    const result = parseDockerImageName("myuser/myapp");
+
+    expect(result.namespace).toBe("myuser");
+    expect(result.repository).toBe("myapp");
+    expect(result.fullName).toBe("myuser/myapp");
+  });
+
+  it("should handle registry prefix by taking last two parts", () => {
+    const result = parseDockerImageName("registry.io/namespace/repo");
+
+    expect(result.namespace).toBe("namespace");
+    expect(result.repository).toBe("repo");
+    expect(result.fullName).toBe("namespace/repo");
+  });
+
+  it("should handle complex registry URLs", () => {
+    const result = parseDockerImageName("my-registry.com/org/project");
+
+    expect(result.namespace).toBe("org");
+    expect(result.repository).toBe("project");
+    expect(result.fullName).toBe("org/project");
+  });
+});
+
+describe("validateDockerImageName", () => {
+  it("should accept valid Docker image names", () => {
+    expect(validateDockerImageName("nginx")).toBe(true);
+    expect(validateDockerImageName("myuser/myapp")).toBe(true);
+    expect(validateDockerImageName("organization/project-name")).toBe(true);
+    expect(validateDockerImageName("user123/app_name")).toBe(true);
+    expect(validateDockerImageName("test.registry/myapp")).toBe(true);
+    expect(validateDockerImageName("ubuntu")).toBe(true);
+    expect(validateDockerImageName("node")).toBe(true);
+    expect(validateDockerImageName("postgres")).toBe(true);
+  });
+
+  it("should reject invalid Docker image names", () => {
+    expect(validateDockerImageName("")).toBe(false);
+    expect(validateDockerImageName(" ")).toBe(false);
+    expect(validateDockerImageName("invalid name with spaces")).toBe(false);
+    expect(validateDockerImageName("-leading-hyphen")).toBe(false);
+    expect(validateDockerImageName("trailing-hyphen-")).toBe(false);
+    expect(validateDockerImageName("_leading_underscore")).toBe(false);
+    expect(validateDockerImageName("trailing_underscore_")).toBe(false);
+    expect(validateDockerImageName(".leading.dot")).toBe(false);
+    expect(validateDockerImageName("trailing.dot.")).toBe(false);
+    expect(validateDockerImageName("user/-invalid")).toBe(false);
+    expect(validateDockerImageName("user/invalid-")).toBe(false);
+    expect(validateDockerImageName("registry.io/namespace/repo/extra")).toBe(
+      false
+    ); // Too many parts
+  });
+
+  it("should handle edge cases", () => {
+    expect(validateDockerImageName("a")).toBe(true); // Single character
+    expect(validateDockerImageName("A")).toBe(true); // Single uppercase
+    expect(validateDockerImageName("1")).toBe(true); // Single number
+    expect(validateDockerImageName("a/b")).toBe(true); // Minimal valid namespaced image
+    expect(validateDockerImageName("user/")).toBe(false); // Empty repository
+    expect(validateDockerImageName("/repo")).toBe(false); // Empty namespace
+  });
+});
+
+describe("parseDockerHubTagsResponse", () => {
+  it("should parse a basic Docker Hub tags response", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 3,
+      results: [
+        {
+          name: "latest",
+          tag_last_pushed: "2023-05-22T14:12:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc123",
+        },
+        {
+          name: "1.20.1",
+          tag_last_pushed: "2023-05-22T14:11:00.000Z",
+          tag_status: "active",
+          digest: "sha256:def456",
+        },
+        {
+          name: "1.20.0",
+          tag_last_pushed: "2023-05-01T10:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:ghi789",
+        },
+      ],
+    };
+
+    const mockRepoResponse = {
+      name: "nginx",
+      description: "Official build of Nginx.",
+      star_count: 12000,
+      pull_count: 1000000000,
+    };
+
+    const result = parseDockerHubTagsResponse(
+      "nginx",
+      mockTagsResponse,
+      mockRepoResponse
+    );
+
+    expect(result.name).toBe("nginx");
+    expect(result.description).toBe("Official build of Nginx.");
+    expect(result.latestVersion).toBe("latest");
+    expect(result.versions).toHaveLength(3);
+    expect(result.metadata?.["registryType"]).toBe("container");
+    expect(result.metadata?.["totalVersions"]).toBe(3);
+    expect(result.metadata?.["starCount"]).toBe(12000);
+    expect(result.metadata?.["pullCount"]).toBe(1000000000);
+    expect(result.metadata?.["totalTags"]).toBe(3);
+
+    // Check version ordering (semver prioritized, then by date)
+    expect(result.versions[0]?.version).toBe("1.20.1"); // Semver comes first
+    expect(result.versions[1]?.version).toBe("1.20.0"); // Semver second
+    expect(result.versions[2]?.version).toBe("latest"); // Non-semver last
+
+    // Check version metadata
+    expect(result.versions[0]?.publishedAt).toBe("2023-05-22T14:11:00.000Z");
+    expect(result.versions[0]?.metadata?.["digest"]).toBe("sha256:def456");
+    expect(result.versions[0]?.metadata?.["status"]).toBe("active");
+    expect(result.versions[0]?.isSemver).toBe(true); // "1.20.1" is semver
+    expect(result.versions[2]?.isSemver).toBe(false); // "latest" is not semver
+  });
+
+  it("should filter out inactive tags", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 3,
+      results: [
+        {
+          name: "latest",
+          tag_last_pushed: "2023-05-22T14:12:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc123",
+        },
+        {
+          name: "old-tag",
+          tag_last_pushed: "2023-01-01T00:00:00.000Z",
+          tag_status: "inactive",
+          digest: "sha256:old123",
+        },
+        {
+          name: "1.0.0",
+          tag_last_pushed: "2023-05-01T10:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:def456",
+        },
+      ],
+    };
+
+    const result = parseDockerHubTagsResponse("myapp", mockTagsResponse);
+
+    // Should only include active tags
+    expect(result.versions).toHaveLength(2);
+    expect(result.versions[0]?.version).toBe("1.0.0"); // Semver first
+    expect(result.versions[1]?.version).toBe("latest"); // Non-semver second
+    expect(result.metadata?.["totalVersions"]).toBe(2);
+  });
+
+  it("should handle version limit filtering", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 5,
+      results: [
+        {
+          name: "3.0.0",
+          tag_last_pushed: "2023-05-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc1",
+        },
+        {
+          name: "2.0.0",
+          tag_last_pushed: "2023-04-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc2",
+        },
+        {
+          name: "1.0.0",
+          tag_last_pushed: "2023-03-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc3",
+        },
+        {
+          name: "0.9.0",
+          tag_last_pushed: "2023-02-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc4",
+        },
+        {
+          name: "0.8.0",
+          tag_last_pushed: "2023-01-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc5",
+        },
+      ],
+    };
+
+    const result = parseDockerHubTagsResponse(
+      "myapp",
+      mockTagsResponse,
+      undefined,
+      {
+        versionLimit: 3,
+      }
+    );
+
+    expect(result.versions).toHaveLength(3);
+    expect(result.versions[0]?.version).toBe("3.0.0");
+    expect(result.versions[1]?.version).toBe("2.0.0");
+    expect(result.versions[2]?.version).toBe("1.0.0");
+    expect(result.metadata?.["filteredVersions"]).toBe(3);
+    expect(result.metadata?.["totalVersions"]).toBe(5);
+  });
+
+  it("should prefer latest tag as latestVersion when available", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 3,
+      results: [
+        {
+          name: "2.0.0",
+          tag_last_pushed: "2023-05-22T14:12:00.000Z", // Most recent
+          tag_status: "active",
+          digest: "sha256:newest",
+        },
+        {
+          name: "latest",
+          tag_last_pushed: "2023-05-20T14:12:00.000Z", // Less recent
+          tag_status: "active",
+          digest: "sha256:latest",
+        },
+        {
+          name: "1.0.0",
+          tag_last_pushed: "2023-05-01T10:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:old",
+        },
+      ],
+    };
+
+    const result = parseDockerHubTagsResponse("myapp", mockTagsResponse);
+
+    // Should prefer "latest" tag over most recent by date
+    expect(result.latestVersion).toBe("latest");
+    // But versions should still be sorted by semver priority
+    expect(result.versions[0]?.version).toBe("2.0.0"); // Semver first
+    expect(result.versions[1]?.version).toBe("1.0.0"); // Semver second
+    expect(result.versions[2]?.version).toBe("latest"); // Non-semver last
+  });
+
+  it("should handle missing repository metadata", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 1,
+      results: [
+        {
+          name: "latest",
+          tag_last_pushed: "2023-05-22T14:12:00.000Z",
+          tag_status: "active",
+          digest: "sha256:abc123",
+        },
+      ],
+    };
+
+    const result = parseDockerHubTagsResponse("myapp", mockTagsResponse);
+
+    expect(result.name).toBe("myapp");
+    expect(result.description).toBeUndefined();
+    expect(result.metadata?.["starCount"]).toBeUndefined();
+    expect(result.metadata?.["pullCount"]).toBeUndefined();
+    expect(result.versions).toHaveLength(1);
+  });
+
+  it("should handle prerelease filtering", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 4,
+      results: [
+        {
+          name: "2.0.0",
+          tag_last_pushed: "2023-05-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:stable",
+        },
+        {
+          name: "2.0.0-rc1",
+          tag_last_pushed: "2023-04-25T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:rc",
+        },
+        {
+          name: "2.0.0-beta",
+          tag_last_pushed: "2023-04-20T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:beta",
+        },
+        {
+          name: "1.0.0",
+          tag_last_pushed: "2023-04-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:old",
+        },
+      ],
+    };
+
+    // Test default behavior (filter out prereleases)
+    const resultFiltered = parseDockerHubTagsResponse(
+      "myapp",
+      mockTagsResponse
+    );
+    expect(resultFiltered.versions).toHaveLength(2);
+    expect(resultFiltered.versions[0]?.version).toBe("2.0.0");
+    expect(resultFiltered.versions[1]?.version).toBe("1.0.0");
+
+    // Test with prereleases included
+    const resultWithPrerelease = parseDockerHubTagsResponse(
+      "myapp",
+      mockTagsResponse,
+      undefined,
+      {
+        includePrerelease: true,
+      }
+    );
+    expect(resultWithPrerelease.versions).toHaveLength(4);
+    expect(resultWithPrerelease.versions[0]?.version).toBe("2.0.0");
+    expect(resultWithPrerelease.versions[1]?.version).toBe("2.0.0-rc1");
+    expect(resultWithPrerelease.versions[2]?.version).toBe("2.0.0-beta");
+    expect(resultWithPrerelease.versions[3]?.version).toBe("1.0.0");
+  });
+
+  it("should handle non-semver tags", () => {
+    const mockTagsResponse: DockerHubTagsResponse = {
+      count: 4,
+      results: [
+        {
+          name: "latest",
+          tag_last_pushed: "2023-05-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:latest",
+        },
+        {
+          name: "stable",
+          tag_last_pushed: "2023-04-20T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:stable",
+        },
+        {
+          name: "2023-05-01",
+          tag_last_pushed: "2023-04-15T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:date",
+        },
+        {
+          name: "1.0.0",
+          tag_last_pushed: "2023-04-01T00:00:00.000Z",
+          tag_status: "active",
+          digest: "sha256:semver",
+        },
+      ],
+    };
+
+    const result = parseDockerHubTagsResponse("myapp", mockTagsResponse);
+
+    expect(result.versions).toHaveLength(4);
+
+    // Check isSemver flags
+    const latestTag = result.versions.find(v => v.version === "latest");
+    const stableTag = result.versions.find(v => v.version === "stable");
+    const dateTag = result.versions.find(v => v.version === "2023-05-01");
+    const semverTag = result.versions.find(v => v.version === "1.0.0");
+
+    expect(latestTag?.isSemver).toBe(false);
+    expect(stableTag?.isSemver).toBe(false);
+    expect(dateTag?.isSemver).toBe(false);
+    expect(semverTag?.isSemver).toBe(true);
+  });
+});

--- a/packages/cli/src/cli/server/registry/docker-adapter.ts
+++ b/packages/cli/src/cli/server/registry/docker-adapter.ts
@@ -1,0 +1,374 @@
+// pattern: Mixed (unavoidable)
+// for the registry adapter interface requirements, we must integrate both
+// network I/O (imperative shell) and data transformation (functional core)
+// in the same class. The parsing logic is extracted to pure functions.
+
+import {
+  createPackageVersion,
+  filterVersions,
+  handleRegistryError,
+  sortVersionsByRecency,
+} from "./utils.js";
+
+import type {
+  PackageFetchOptions,
+  PackageFetchResult,
+  PackageInfo,
+  PackageSearchOptions,
+  PackageSearchResults,
+  PackageVersion,
+  RegistryAdapter,
+  RegistryConfig,
+} from "./types.js";
+
+/**
+ * Docker Hub registry API response types
+ */
+export interface DockerHubTagsResponse {
+  count: number;
+  next?: string;
+  previous?: string;
+  results: {
+    name: string;
+    tag_last_pushed: string;
+    tag_status: string;
+    digest: string;
+    [key: string]: unknown;
+  }[];
+}
+
+interface DockerHubRepositoryResponse {
+  name: string;
+  description?: string;
+  star_count: number;
+  pull_count: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Parse Docker image name into namespace and repository
+ * Pure function - can be unit tested
+ */
+export function parseDockerImageName(imageName: string): {
+  namespace: string;
+  repository: string;
+  fullName: string;
+} {
+  // Handle official images (no namespace)
+  if (!imageName.includes("/")) {
+    return {
+      namespace: "library",
+      repository: imageName,
+      fullName: `library/${imageName}`,
+    };
+  }
+
+  const parts = imageName.split("/");
+  if (parts.length === 2) {
+    const namespace = parts[0];
+    const repository = parts[1];
+    if (!namespace || !repository) {
+      throw new Error(`Invalid image name: ${imageName}`);
+    }
+    return {
+      namespace,
+      repository,
+      fullName: imageName,
+    };
+  }
+
+  // Handle registry.com/namespace/repo format - just take the last two parts
+  const namespace = parts[parts.length - 2];
+  const repository = parts[parts.length - 1];
+  if (!namespace || !repository) {
+    throw new Error(`Invalid image name: ${imageName}`);
+  }
+  return {
+    namespace,
+    repository,
+    fullName: `${namespace}/${repository}`,
+  };
+}
+
+/**
+ * Validate that an image name is valid for Docker Hub
+ * Pure function - can be unit tested
+ */
+export function validateDockerImageName(imageName: string): boolean {
+  if (!imageName || imageName.trim() === "") {
+    return false;
+  }
+
+  // Basic validation for Docker image names
+  // Allow: letters, numbers, hyphens, underscores, dots, and single slash
+  const dockerImagePattern = /^[a-zA-Z0-9]([a-zA-Z0-9._-]*\/)?[a-zA-Z0-9._-]*$/;
+
+  if (!dockerImagePattern.test(imageName)) {
+    return false;
+  }
+
+  // Additional validations
+  const parts = imageName.split("/");
+
+  // Too many slashes (only support namespace/repo format)
+  if (parts.length > 2) {
+    return false;
+  }
+
+  // Each part must be valid
+  for (const part of parts) {
+    if (!part || part.length === 0) {
+      return false;
+    }
+
+    // Parts cannot start or end with special characters
+    if (
+      part.startsWith("-") ||
+      part.startsWith("_") ||
+      part.startsWith(".") ||
+      part.endsWith("-") ||
+      part.endsWith("_") ||
+      part.endsWith(".")
+    ) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Parse Docker Hub tags response into standardized PackageInfo
+ * Pure function - can be unit tested without network calls
+ */
+export function parseDockerHubTagsResponse(
+  imageName: string,
+  tagsData: DockerHubTagsResponse,
+  repositoryData?: DockerHubRepositoryResponse,
+  options: PackageFetchOptions = {}
+): PackageInfo {
+  const { results } = tagsData;
+
+  // Convert tags to PackageVersion array
+  const allVersions: PackageVersion[] = results
+    .filter(tag => tag.tag_status === "active") // Only include active tags
+    .map(tag => {
+      return createPackageVersion(tag.name, tag.tag_last_pushed, {
+        digest: tag.digest,
+        status: tag.tag_status,
+      });
+    });
+
+  // Sort versions by recency (latest first)
+  const sortedVersions = sortVersionsByRecency(allVersions);
+
+  // Apply filtering based on options
+  const filterOptions: { includePrerelease?: boolean; versionLimit?: number } =
+    {};
+  if (options.includePrerelease !== undefined) {
+    filterOptions.includePrerelease = options.includePrerelease;
+  }
+  if (options.versionLimit !== undefined) {
+    filterOptions.versionLimit = options.versionLimit;
+  }
+  const filteredVersions = filterVersions(sortedVersions, filterOptions);
+
+  // Find the "latest" tag if it exists
+  const latestTag = results.find(tag => tag.name === "latest");
+  const latestVersion = latestTag?.name ?? filteredVersions[0]?.version;
+
+  const packageInfo: PackageInfo = {
+    name: imageName,
+    versions: filteredVersions,
+    metadata: {
+      registryType: "container",
+      totalVersions: allVersions.length,
+      filteredVersions: filteredVersions.length,
+      starCount: repositoryData?.star_count,
+      pullCount: repositoryData?.pull_count,
+      totalTags: tagsData.count,
+    },
+  };
+
+  // Add optional fields only if they exist
+  if (latestVersion) {
+    packageInfo.latestVersion = latestVersion;
+  }
+
+  if (repositoryData?.description) {
+    packageInfo.description = repositoryData.description;
+  }
+
+  return packageInfo;
+}
+
+/**
+ * Docker Hub registry adapter for fetching container image information
+ */
+export class DockerHubRegistryAdapter implements RegistryAdapter {
+  readonly config: RegistryConfig;
+
+  constructor(baseUrl = "https://hub.docker.com") {
+    this.config = {
+      type: "container",
+      displayName: "Docker Hub Registry",
+      baseUrl,
+    };
+  }
+
+  /**
+   * Fetch detailed information about a specific Docker image
+   */
+  async fetchPackage(
+    imageName: string,
+    options: PackageFetchOptions = {}
+  ): Promise<PackageFetchResult> {
+    if (!this.validatePackageName(imageName)) {
+      return {
+        success: false,
+        error: `Invalid Docker image name: ${imageName}`,
+      };
+    }
+
+    try {
+      const { fullName } = parseDockerImageName(imageName);
+
+      // Fetch tags from Docker Hub API
+      const tagsUrl = `${this.config.baseUrl}/v2/repositories/${fullName}/tags/`;
+      const tagsResponse = await fetch(tagsUrl);
+
+      if (!tagsResponse.ok) {
+        if (tagsResponse.status === 404) {
+          return {
+            success: false,
+            error: `Docker image '${imageName}' not found in Docker Hub`,
+          };
+        }
+        return {
+          success: false,
+          error: `Docker Hub API error: ${tagsResponse.status} ${tagsResponse.statusText}`,
+        };
+      }
+
+      const tagsData = (await tagsResponse.json()) as DockerHubTagsResponse;
+
+      // Optionally fetch repository metadata for additional info
+      let repositoryData: DockerHubRepositoryResponse | undefined;
+      try {
+        const repoUrl = `${this.config.baseUrl}/v2/repositories/${fullName}/`;
+        const repoResponse = await fetch(repoUrl);
+        if (repoResponse.ok) {
+          repositoryData =
+            (await repoResponse.json()) as DockerHubRepositoryResponse;
+        }
+      } catch {
+        // Repository metadata is optional, continue without it
+      }
+
+      const packageInfo = parseDockerHubTagsResponse(
+        imageName,
+        tagsData,
+        repositoryData,
+        options
+      );
+
+      return {
+        success: true,
+        package: packageInfo,
+      };
+    } catch (error) {
+      const errorMessage = handleRegistryError(
+        error,
+        "Docker Hub",
+        "fetch image"
+      );
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Search for images in Docker Hub registry
+   * Note: Docker Hub search API has limitations and requires authentication for higher limits
+   */
+  async searchPackages(
+    options: PackageSearchOptions
+  ): Promise<PackageSearchResults> {
+    try {
+      const searchUrl = new URL(
+        "/v2/search/repositories/",
+        this.config.baseUrl
+      );
+      searchUrl.searchParams.set("query", options.query);
+      searchUrl.searchParams.set("page_size", String(options.limit ?? 20));
+      searchUrl.searchParams.set(
+        "page",
+        String(Math.floor((options.offset ?? 0) / (options.limit ?? 20)) + 1)
+      );
+
+      const response = await fetch(searchUrl.toString());
+
+      if (!response.ok) {
+        return {
+          success: false,
+          error: `Docker Hub search error: ${response.status} ${response.statusText}`,
+        };
+      }
+
+      const data = (await response.json()) as {
+        results: {
+          name: string;
+          description?: string;
+          star_count: number;
+          [key: string]: unknown;
+        }[];
+      };
+
+      const results = data.results.map(item => {
+        const result: {
+          name: string;
+          description?: string;
+          score?: number;
+          metadata?: Record<string, unknown>;
+        } = {
+          name: item.name,
+          score: item.star_count, // Use star count as relevance score
+          metadata: {
+            stars: item.star_count,
+          },
+        };
+
+        // Add optional description only if it exists
+        if (item.description) {
+          result.description = item.description;
+        }
+
+        return result;
+      });
+
+      return {
+        success: true,
+        results,
+      };
+    } catch (error) {
+      const errorMessage = handleRegistryError(
+        error,
+        "Docker Hub",
+        "search images"
+      );
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Validate that an image name is valid for Docker Hub
+   */
+  validatePackageName(imageName: string): boolean {
+    return validateDockerImageName(imageName);
+  }
+}

--- a/packages/cli/src/cli/server/registry/factory.test.ts
+++ b/packages/cli/src/cli/server/registry/factory.test.ts
@@ -1,8 +1,10 @@
 // pattern: Test
 import { describe, expect, it } from "vitest";
 
+import { DockerHubRegistryAdapter } from "./docker-adapter.js";
 import { RegistryAdapterFactory } from "./factory.js";
 import { NpmRegistryAdapter } from "./npm-adapter.js";
+import { PypiRegistryAdapter } from "./pypi-adapter.js";
 
 describe("RegistryAdapterFactory", () => {
   describe("createAdapter", () => {
@@ -13,16 +15,18 @@ describe("RegistryAdapterFactory", () => {
       expect(adapter.config.displayName).toBe("NPM Registry");
     });
 
-    it("should throw error for unimplemented python type", () => {
-      expect(() => {
-        RegistryAdapterFactory.createAdapter("python");
-      }).toThrow("Python registry adapter not yet implemented");
+    it("should create PyPI adapter for python type", () => {
+      const adapter = RegistryAdapterFactory.createAdapter("python");
+      expect(adapter).toBeInstanceOf(PypiRegistryAdapter);
+      expect(adapter.config.type).toBe("python");
+      expect(adapter.config.displayName).toBe("PyPI Registry");
     });
 
-    it("should throw error for unimplemented container type", () => {
-      expect(() => {
-        RegistryAdapterFactory.createAdapter("container");
-      }).toThrow("Container registry adapter not yet implemented");
+    it("should create Docker Hub adapter for container type", () => {
+      const adapter = RegistryAdapterFactory.createAdapter("container");
+      expect(adapter).toBeInstanceOf(DockerHubRegistryAdapter);
+      expect(adapter.config.type).toBe("container");
+      expect(adapter.config.displayName).toBe("Docker Hub Registry");
     });
 
     it("should throw error for unsupported type", () => {
@@ -38,11 +42,11 @@ describe("RegistryAdapterFactory", () => {
 
       expect(registries).toEqual([
         { type: "node", displayName: "Node.js (NPM)", implemented: true },
-        { type: "python", displayName: "Python (PyPI)", implemented: false },
+        { type: "python", displayName: "Python (PyPI)", implemented: true },
         {
           type: "container",
           displayName: "Container (Docker)",
-          implemented: false,
+          implemented: true,
         },
       ]);
     });
@@ -54,15 +58,18 @@ describe("RegistryAdapterFactory", () => {
 
       expect(available).toEqual([
         { type: "node", displayName: "Node.js (NPM)" },
+        { type: "python", displayName: "Python (PyPI)" },
+        { type: "container", displayName: "Container (Docker)" },
       ]);
     });
 
-    it("should not include unimplemented registries", () => {
+    it("should include all implemented registries", () => {
       const available = RegistryAdapterFactory.getAvailableRegistries();
       const types = available.map(r => r.type);
 
-      expect(types).not.toContain("python");
-      expect(types).not.toContain("container");
+      expect(types).toContain("node");
+      expect(types).toContain("python");
+      expect(types).toContain("container");
     });
   });
 });

--- a/packages/cli/src/cli/server/registry/factory.ts
+++ b/packages/cli/src/cli/server/registry/factory.ts
@@ -1,6 +1,8 @@
 // pattern: Functional Core
 
+import { DockerHubRegistryAdapter } from "./docker-adapter.js";
 import { NpmRegistryAdapter } from "./npm-adapter.js";
+import { PypiRegistryAdapter } from "./pypi-adapter.js";
 
 import type { RegistryAdapter, RegistryType } from "./types.js";
 
@@ -18,10 +20,10 @@ export class RegistryAdapterFactory {
         return new NpmRegistryAdapter();
 
       case "python":
-        throw new Error("Python registry adapter not yet implemented");
+        return new PypiRegistryAdapter();
 
       case "container":
-        throw new Error("Container registry adapter not yet implemented");
+        return new DockerHubRegistryAdapter();
 
       default:
         throw new Error(`Unsupported registry type: ${type}`);
@@ -38,11 +40,11 @@ export class RegistryAdapterFactory {
   }[] {
     return [
       { type: "node", displayName: "Node.js (NPM)", implemented: true },
-      { type: "python", displayName: "Python (PyPI)", implemented: false },
+      { type: "python", displayName: "Python (PyPI)", implemented: true },
       {
         type: "container",
         displayName: "Container (Docker)",
-        implemented: false,
+        implemented: true,
       },
     ];
   }

--- a/packages/cli/src/cli/server/registry/pypi-adapter.test.ts
+++ b/packages/cli/src/cli/server/registry/pypi-adapter.test.ts
@@ -1,0 +1,275 @@
+// pattern: Functional Core
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parsePypiPackageResponse,
+  type PypiPackageResponse,
+  validatePypiPackageName,
+} from "./pypi-adapter.js";
+
+describe("validatePypiPackageName", () => {
+  it("should accept valid Python package names", () => {
+    expect(validatePypiPackageName("requests")).toBe(true);
+    expect(validatePypiPackageName("django-rest-framework")).toBe(true);
+    expect(validatePypiPackageName("Flask")).toBe(true);
+    expect(validatePypiPackageName("numpy")).toBe(true);
+    expect(validatePypiPackageName("tensorflow-gpu")).toBe(true);
+    expect(validatePypiPackageName("scikit-learn")).toBe(true);
+    expect(validatePypiPackageName("django_extensions")).toBe(true);
+    expect(validatePypiPackageName("Pillow")).toBe(true);
+    expect(validatePypiPackageName("requests-oauthlib")).toBe(true);
+    expect(validatePypiPackageName("python-dateutil")).toBe(true);
+    expect(validatePypiPackageName("pytz")).toBe(true);
+    expect(validatePypiPackageName("six")).toBe(true);
+    expect(validatePypiPackageName("setuptools")).toBe(true);
+    expect(validatePypiPackageName("pip")).toBe(true);
+    expect(validatePypiPackageName("wheel")).toBe(true);
+  });
+
+  it("should reject invalid Python package names", () => {
+    expect(validatePypiPackageName("")).toBe(false);
+    expect(validatePypiPackageName(" ")).toBe(false);
+    expect(validatePypiPackageName("package with spaces")).toBe(false);
+    expect(validatePypiPackageName("package/with/slashes")).toBe(false);
+    expect(validatePypiPackageName("package\\with\\backslashes")).toBe(false);
+    expect(validatePypiPackageName("-leading-hyphen")).toBe(false);
+    expect(validatePypiPackageName("trailing-hyphen-")).toBe(false);
+    expect(validatePypiPackageName("_leading_underscore")).toBe(false);
+    expect(validatePypiPackageName("trailing_underscore_")).toBe(false);
+    expect(validatePypiPackageName("@scoped/package")).toBe(false); // No scoped packages in PyPI
+  });
+
+  it("should handle edge cases", () => {
+    expect(validatePypiPackageName("a")).toBe(true); // Single character
+    expect(validatePypiPackageName("A")).toBe(true); // Single uppercase
+    expect(validatePypiPackageName("1")).toBe(true); // Single number
+    expect(validatePypiPackageName("a1")).toBe(true); // Letter + number
+    expect(validatePypiPackageName("1a")).toBe(true); // Number + letter
+  });
+});
+
+describe("parsePypiPackageResponse", () => {
+  it("should parse a basic PyPI package response", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "requests",
+        version: "2.31.0",
+        summary: "Python HTTP for Humans.",
+        description: "A simple, yet elegant HTTP library.",
+      },
+      releases: {
+        "2.31.0": [
+          {
+            upload_time: "2023-05-22T14:12:00.000Z",
+            filename: "requests-2.31.0-py3-none-any.whl",
+          },
+        ],
+        "2.30.0": [
+          {
+            upload_time: "2023-05-03T10:30:00.000Z",
+            filename: "requests-2.30.0-py3-none-any.whl",
+          },
+        ],
+        "2.29.0": [
+          {
+            upload_time: "2023-05-01T09:15:00.000Z",
+            filename: "requests-2.29.0-py3-none-any.whl",
+          },
+        ],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    expect(result.name).toBe("requests");
+    expect(result.description).toBe("Python HTTP for Humans.");
+    expect(result.latestVersion).toBe("2.31.0");
+    expect(result.versions).toHaveLength(3);
+    expect(result.metadata?.["registryType"]).toBe("python");
+    expect(result.metadata?.["totalVersions"]).toBe(3);
+
+    // Check version ordering (latest first)
+    expect(result.versions[0]?.version).toBe("2.31.0");
+    expect(result.versions[1]?.version).toBe("2.30.0");
+    expect(result.versions[2]?.version).toBe("2.29.0");
+
+    // Check version metadata
+    expect(result.versions[0]?.isSemver).toBe(true);
+    expect(result.versions[0]?.publishedAt).toBe("2023-05-22T14:12:00.000Z");
+    expect(result.versions[0]?.metadata?.["fileCount"]).toBe(1);
+  });
+
+  it("should handle empty releases", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "test-package",
+        version: "1.0.0",
+        summary: "Test package",
+      },
+      releases: {
+        "1.0.0": [
+          {
+            upload_time: "2023-01-01T00:00:00.000Z",
+            filename: "test-package-1.0.0.tar.gz",
+          },
+        ],
+        "0.9.0": [], // Empty release (yanked)
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    expect(result.versions).toHaveLength(1);
+    expect(result.versions[0]?.version).toBe("1.0.0");
+    expect(result.metadata?.["totalVersions"]).toBe(1);
+  });
+
+  it("should apply version limit filtering", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "test-package",
+        version: "3.0.0",
+        summary: "Test package",
+      },
+      releases: {
+        "3.0.0": [{ upload_time: "2023-03-01T00:00:00.000Z" }],
+        "2.0.0": [{ upload_time: "2023-02-01T00:00:00.000Z" }],
+        "1.0.0": [{ upload_time: "2023-01-01T00:00:00.000Z" }],
+        "0.9.0": [{ upload_time: "2022-12-01T00:00:00.000Z" }],
+        "0.8.0": [{ upload_time: "2022-11-01T00:00:00.000Z" }],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse, { versionLimit: 3 });
+
+    expect(result.versions).toHaveLength(3);
+    expect(result.versions[0]?.version).toBe("3.0.0");
+    expect(result.versions[1]?.version).toBe("2.0.0");
+    expect(result.versions[2]?.version).toBe("1.0.0");
+    expect(result.metadata?.["filteredVersions"]).toBe(3);
+    expect(result.metadata?.["totalVersions"]).toBe(5);
+  });
+
+  it("should filter prerelease versions by default", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "test-package",
+        version: "2.0.0",
+        summary: "Test package",
+      },
+      releases: {
+        "2.0.0": [{ upload_time: "2023-02-01T00:00:00.000Z" }],
+        "2.0.0-rc1": [{ upload_time: "2023-01-25T00:00:00.000Z" }],
+        "2.0.0-beta1": [{ upload_time: "2023-01-20T00:00:00.000Z" }],
+        "2.0.0-alpha1": [{ upload_time: "2023-01-15T00:00:00.000Z" }],
+        "1.0.0": [{ upload_time: "2023-01-01T00:00:00.000Z" }],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    // Should only include stable versions
+    expect(result.versions).toHaveLength(2);
+    expect(result.versions[0]?.version).toBe("2.0.0");
+    expect(result.versions[1]?.version).toBe("1.0.0");
+  });
+
+  it("should include prerelease versions when requested", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "test-package",
+        version: "2.0.0",
+        summary: "Test package",
+      },
+      releases: {
+        "2.0.0": [{ upload_time: "2023-02-01T00:00:00.000Z" }],
+        "2.0.0-rc1": [{ upload_time: "2023-01-25T00:00:00.000Z" }],
+        "1.0.0": [{ upload_time: "2023-01-01T00:00:00.000Z" }],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse, {
+      includePrerelease: true,
+    });
+
+    expect(result.versions).toHaveLength(3);
+    expect(result.versions[0]?.version).toBe("2.0.0");
+    expect(result.versions[1]?.version).toBe("2.0.0-rc1");
+    expect(result.versions[2]?.version).toBe("1.0.0");
+  });
+
+  it("should handle non-semver versions", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "legacy-package",
+        version: "latest",
+        summary: "Legacy package with non-semver versions",
+      },
+      releases: {
+        latest: [{ upload_time: "2023-03-01T00:00:00.000Z" }],
+        stable: [{ upload_time: "2023-02-01T00:00:00.000Z" }],
+        "2023.01.15": [{ upload_time: "2023-01-15T00:00:00.000Z" }],
+        "1.0.0": [{ upload_time: "2023-01-01T00:00:00.000Z" }],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    expect(result.versions).toHaveLength(4);
+
+    // Check isSemver flag
+    const latestVersion = result.versions.find(v => v.version === "latest");
+    const stableVersion = result.versions.find(v => v.version === "stable");
+    const dateVersion = result.versions.find(v => v.version === "2023.01.15");
+    const semverVersion = result.versions.find(v => v.version === "1.0.0");
+
+    expect(latestVersion?.isSemver).toBe(false);
+    expect(stableVersion?.isSemver).toBe(false);
+    expect(dateVersion?.isSemver).toBe(false);
+    expect(semverVersion?.isSemver).toBe(true);
+  });
+
+  it("should handle missing optional fields", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "minimal-package",
+        version: "1.0.0",
+      },
+      releases: {
+        "1.0.0": [{ upload_time: "2023-01-01T00:00:00.000Z" }],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    expect(result.name).toBe("minimal-package");
+    expect(result.description).toBeUndefined();
+    expect(result.latestVersion).toBe("1.0.0");
+    expect(result.versions).toHaveLength(1);
+  });
+
+  it("should handle missing upload_time gracefully", () => {
+    const mockResponse: PypiPackageResponse = {
+      info: {
+        name: "test-package",
+        version: "1.0.0",
+      },
+      releases: {
+        "1.0.0": [
+          {
+            filename: "test-package-1.0.0.tar.gz",
+            // upload_time is missing
+          } as unknown as { upload_time: string },
+        ],
+      },
+    };
+
+    const result = parsePypiPackageResponse(mockResponse);
+
+    expect(result.versions).toHaveLength(1);
+    expect(result.versions[0]?.version).toBe("1.0.0");
+    // Should get current timestamp as fallback
+    expect(result.versions[0]?.publishedAt).toBeDefined();
+  });
+});

--- a/packages/cli/src/cli/server/registry/pypi-adapter.ts
+++ b/packages/cli/src/cli/server/registry/pypi-adapter.ts
@@ -1,0 +1,218 @@
+// pattern: Mixed (unavoidable)
+// for the registry adapter interface requirements, we must integrate both
+// network I/O (imperative shell) and data transformation (functional core)
+// in the same class. The parsing logic is extracted to pure functions.
+
+import {
+  createPackageVersion,
+  filterVersions,
+  handleRegistryError,
+  sortVersionsByRecency,
+  validatePackageName,
+} from "./utils.js";
+
+import type {
+  PackageFetchOptions,
+  PackageFetchResult,
+  PackageInfo,
+  PackageSearchOptions,
+  PackageSearchResults,
+  PackageVersion,
+  RegistryAdapter,
+  RegistryConfig,
+} from "./types.js";
+
+/**
+ * PyPI registry API response types
+ */
+export interface PypiPackageResponse {
+  info: {
+    name: string;
+    version: string;
+    summary?: string;
+    description?: string;
+    [key: string]: unknown;
+  };
+  releases: Record<
+    string,
+    {
+      upload_time: string;
+      [key: string]: unknown;
+    }[]
+  >;
+}
+
+// interface PypiSearchResponse {
+//   projects: Array<{
+//     name: string;
+//     version: string;
+//     description?: string;
+//     [key: string]: unknown;
+//   }>;
+// }
+
+/**
+ * Parse PyPI API response into standardized PackageInfo
+ * Pure function - can be unit tested without network calls
+ */
+export function parsePypiPackageResponse(
+  data: PypiPackageResponse,
+  options: PackageFetchOptions = {}
+): PackageInfo {
+  const { releases } = data;
+  const { info } = data;
+
+  // Convert releases to PackageVersion array
+  const allVersions: PackageVersion[] = [];
+
+  for (const [version, versionData] of Object.entries(releases)) {
+    // Skip empty releases (can happen with yanked packages)
+    if (versionData.length === 0) {
+      continue;
+    }
+
+    // Use the first upload time if multiple files exist for a version
+    const uploadTime = versionData[0]?.upload_time ?? new Date().toISOString();
+
+    const packageVersion = createPackageVersion(version, uploadTime, {
+      fileCount: versionData.length,
+    });
+
+    allVersions.push(packageVersion);
+  }
+
+  // Sort versions by recency (latest first)
+  const sortedVersions = sortVersionsByRecency(allVersions);
+
+  // Apply filtering based on options
+  const filterOptions: { includePrerelease?: boolean; versionLimit?: number } =
+    {};
+  if (options.includePrerelease !== undefined) {
+    filterOptions.includePrerelease = options.includePrerelease;
+  }
+  if (options.versionLimit !== undefined) {
+    filterOptions.versionLimit = options.versionLimit;
+  }
+  const filteredVersions = filterVersions(sortedVersions, filterOptions);
+
+  const packageInfo: PackageInfo = {
+    name: info.name,
+    versions: filteredVersions,
+    latestVersion: info.version, // PyPI's reported latest version
+    metadata: {
+      registryType: "python",
+      totalVersions: allVersions.length,
+      filteredVersions: filteredVersions.length,
+    },
+  };
+
+  // Add optional description only if it exists
+  const description = info.summary ?? info.description;
+  if (description) {
+    packageInfo.description = description;
+  }
+
+  return packageInfo;
+}
+
+/**
+ * Validate that a package name is valid for PyPI
+ * Pure function - can be unit tested
+ */
+export function validatePypiPackageName(packageName: string): boolean {
+  return validatePackageName(packageName, {
+    allowScoped: false, // PyPI doesn't use scoped packages like NPM
+    minLength: 1,
+    maxLength: 214, // Same as NPM for consistency
+    // Python package names: letters, numbers, hyphens, underscores, dots
+    pattern: /^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$/,
+    forbiddenChars: [" ", "/", "\\"], // Common forbidden characters
+  });
+}
+
+/**
+ * PyPI registry adapter for fetching Python package information
+ */
+export class PypiRegistryAdapter implements RegistryAdapter {
+  readonly config: RegistryConfig;
+
+  constructor(baseUrl = "https://pypi.org") {
+    this.config = {
+      type: "python",
+      displayName: "PyPI Registry",
+      baseUrl,
+    };
+  }
+
+  /**
+   * Fetch detailed information about a specific PyPI package
+   */
+  async fetchPackage(
+    packageName: string,
+    options: PackageFetchOptions = {}
+  ): Promise<PackageFetchResult> {
+    if (!this.validatePackageName(packageName)) {
+      return {
+        success: false,
+        error: `Invalid Python package name: ${packageName}`,
+      };
+    }
+
+    try {
+      const encodedName = encodeURIComponent(packageName);
+      const url = `${this.config.baseUrl}/pypi/${encodedName}/json`;
+
+      const response = await fetch(url);
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          return {
+            success: false,
+            error: `Package '${packageName}' not found in PyPI registry`,
+          };
+        }
+        return {
+          success: false,
+          error: `PyPI registry error: ${response.status} ${response.statusText}`,
+        };
+      }
+
+      const data = (await response.json()) as PypiPackageResponse;
+      const packageInfo = parsePypiPackageResponse(data, options);
+
+      return {
+        success: true,
+        package: packageInfo,
+      };
+    } catch (error) {
+      const errorMessage = handleRegistryError(error, "PyPI", "fetch package");
+      return {
+        success: false,
+        error: errorMessage,
+      };
+    }
+  }
+
+  /**
+   * Search for packages in the PyPI registry
+   * Note: PyPI doesn't have a direct search API, so this is a placeholder
+   */
+  async searchPackages(
+    _options: PackageSearchOptions
+  ): Promise<PackageSearchResults> {
+    // PyPI's simple search API is not well-documented and changes frequently
+    // For now, we'll return a not-implemented error
+    return {
+      success: false,
+      error:
+        "PyPI package search is not implemented yet. Please specify the exact package name.",
+    };
+  }
+
+  /**
+   * Validate that a package name is valid for PyPI
+   */
+  validatePackageName(packageName: string): boolean {
+    return validatePypiPackageName(packageName);
+  }
+}

--- a/packages/cli/src/cli/server/registry/utils.ts
+++ b/packages/cli/src/cli/server/registry/utils.ts
@@ -1,0 +1,216 @@
+// pattern: Functional Core
+
+import { rcompare as semverRcompare, valid as isValidSemver } from "semver";
+
+import type { PackageVersion } from "./types.js";
+
+/**
+ * Sort package versions by semantic versioning rules where possible,
+ * falling back to string comparison for non-semver versions
+ */
+export function sortVersionsByRecency(
+  versions: PackageVersion[]
+): PackageVersion[] {
+  return versions.sort((a, b) => {
+    // Both versions are valid semver - use semver comparison
+    if (a.isSemver && b.isSemver) {
+      return semverRcompare(a.version, b.version);
+    }
+
+    // Neither version is semver - use publishedAt date
+    if (!a.isSemver && !b.isSemver) {
+      return (
+        new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime()
+      );
+    }
+
+    // Mixed semver and non-semver - prioritize semver versions
+    if (a.isSemver && !b.isSemver) {
+      return -1;
+    }
+    if (!a.isSemver && b.isSemver) {
+      return 1;
+    }
+
+    return 0;
+  });
+}
+
+/**
+ * Check if a version string is valid semver
+ */
+export function isValidSemanticVersion(version: string): boolean {
+  return isValidSemver(version) !== null;
+}
+
+/**
+ * Validate a package name against common registry patterns
+ */
+export interface PackageNameValidationRules {
+  /** Allow scoped packages (e.g., @org/package) */
+  allowScoped?: boolean;
+  /** Minimum length */
+  minLength?: number;
+  /** Maximum length */
+  maxLength?: number;
+  /** Custom regex pattern to match */
+  pattern?: RegExp;
+  /** Additional forbidden characters */
+  forbiddenChars?: string[];
+}
+
+/**
+ * Validate package name with flexible rules
+ */
+export function validatePackageName(
+  packageName: string,
+  rules: PackageNameValidationRules = {}
+): boolean {
+  const {
+    allowScoped = true,
+    minLength = 1,
+    maxLength = 214,
+    pattern,
+    forbiddenChars = [],
+  } = rules;
+
+  // Basic length checks
+  if (packageName.length < minLength || packageName.length > maxLength) {
+    return false;
+  }
+
+  // Custom pattern check
+  if (pattern && !pattern.test(packageName)) {
+    return false;
+  }
+
+  // Forbidden characters check
+  for (const char of forbiddenChars) {
+    if (packageName.includes(char)) {
+      return false;
+    }
+  }
+
+  // Handle scoped packages
+  if (packageName.startsWith("@")) {
+    if (!allowScoped) {
+      return false;
+    }
+
+    const parts = packageName.split("/");
+    if (parts.length !== 2) {
+      return false;
+    }
+
+    const [scope, name] = parts;
+    if (!scope || !name || scope.length <= 1 || name.length === 0) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Standard error handling for registry API responses
+ */
+export function handleRegistryError(
+  error: unknown,
+  registryName: string,
+  operation: string
+): string {
+  if (error instanceof Error) {
+    if (error.message.includes("404") || error.message.includes("Not Found")) {
+      return `Package not found in ${registryName}`;
+    }
+    if (error.message.includes("403") || error.message.includes("Forbidden")) {
+      return `Access denied to ${registryName} registry`;
+    }
+    if (error.message.includes("rate limit")) {
+      return `${registryName} rate limit exceeded. Please try again later`;
+    }
+    return `${registryName} registry error: ${error.message}`;
+  }
+
+  return `Failed to ${operation} from ${registryName}: ${String(error)}`;
+}
+
+/**
+ * Parse and standardize version information from different registries
+ */
+export function createPackageVersion(
+  version: string,
+  publishedAt: string | Date,
+  metadata: Record<string, unknown> = {}
+): PackageVersion {
+  const publishedAtString =
+    publishedAt instanceof Date ? publishedAt.toISOString() : publishedAt;
+
+  return {
+    version,
+    publishedAt: publishedAtString,
+    isSemver: isValidSemanticVersion(version),
+    metadata,
+  };
+}
+
+/**
+ * Filter versions based on options
+ */
+export function filterVersions(
+  versions: PackageVersion[],
+  options: {
+    includePrerelease?: boolean;
+    versionLimit?: number;
+  } = {}
+): PackageVersion[] {
+  let filtered = versions;
+
+  // Filter out pre-release versions if not requested
+  if (!options.includePrerelease) {
+    filtered = filtered.filter(v => {
+      // For semver, check if it's a prerelease
+      if (v.isSemver) {
+        return !v.version.includes("-");
+      }
+      // For non-semver, check for common prerelease indicators
+      const lowerVersion = v.version.toLowerCase();
+      return !(
+        lowerVersion.includes("alpha") ||
+        lowerVersion.includes("beta") ||
+        lowerVersion.includes("rc") ||
+        lowerVersion.includes("pre") ||
+        lowerVersion.includes("dev") ||
+        lowerVersion.includes("snapshot")
+      );
+    });
+  }
+
+  // Apply version limit
+  if (options.versionLimit && options.versionLimit > 0) {
+    filtered = filtered.slice(0, options.versionLimit);
+  }
+
+  return filtered;
+}
+
+/**
+ * Format version for display in prompts
+ */
+export function formatVersionForDisplay(
+  version: PackageVersion,
+  showDate = false
+): string {
+  if (!showDate) {
+    return version.version;
+  }
+
+  const date = new Date(version.publishedAt);
+  const formattedDate = date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+
+  return `${version.version} (${formattedDate})`;
+}

--- a/packages/cli/src/config/types/index.ts
+++ b/packages/cli/src/config/types/index.ts
@@ -19,6 +19,7 @@ export {
   NodeMcpServerV1 as NodeMcpServer,
   NodeOptionsV1 as NodeOptions,
   ProjectOptionsV1 as ProjectOptions,
+  PythonMcpServerV1 as PythonMcpServer,
   SandboxOptionsV1 as SandboxOptions,
   ServerSpecV1 as ServerSpec,
   SettingsBaseV1 as SettingsBase,


### PR DESCRIPTION
    feat(cli): add escape key navigation to registry interactive flow
    
    - Add escape-aware select prompt to distinguish escape from Ctrl+C
    - Update registry prompts to use navigation-aware components
    - Fix confirmation prompt to require explicit y/n (no default on enter)
    - Add back navigation support throughout registry server add flow
    - Registry type selection: escape exits (first prompt)
    - Package input: escape/Ctrl+C goes back to registry selection
    - Version selection: escape goes back to package input
    - Confirmation: escape goes back to version selection

    fix(tests): update unit tests for implemented registry adapters
    
    Registry adapters for PyPI and Docker Hub are now implemented, so the tests
    expecting them to throw 'not implemented' errors needed to be updated to
    verify correct functionality instead.
    
    Changes:
    - Update registry-server-generator tests to verify Python and Container configs
    - Update factory tests to verify PyPI and Docker Hub adapter creation
    - Update expectations for getSupportedRegistries and getAvailableRegistries


    fix(container): enforce security model for container digest verification
    
    Container installations were incorrectly reporting success when remote
    digest verification failed due to authentication or rate limiting issues.
    This violated the trust-on-first-use security model by allowing containers
    to be installed without verifying their integrity.
    
    Changes:
    - Fix shouldPullImage to treat both 401 and 403 errors as failures
    - Prevent installation when remote digest cannot be verified
    - Maintain security guarantees for container trust anchors
    - Add registry adapters for PyPI and Docker Hub to support multi-package-type server add command
    
    This ensures container installations fail safely when digest verification
    is impossible, preventing potential security vulnerabilities.