### PR TITLE
fix: handle --user flag in server name extraction

### DIFF
--- a/packages/cli/src/installer/discovery/server-detector.test.ts
+++ b/packages/cli/src/installer/discovery/server-detector.test.ts
@@ -164,6 +164,71 @@ describe("server-detector", () => {
 
       expect(extractMcpadreServerName(incompleteServer, "simple")).toBe(null);
     });
+
+    it("extracts server name from simple format with --user flag", () => {
+      const userModeServer = {
+        command: "mcpadre",
+        args: ["run", "--user", "my-server"],
+      };
+
+      expect(extractMcpadreServerName(userModeServer, "simple")).toBe(
+        "my-server"
+      );
+    });
+
+    it("extracts server name from stdio format with --user flag", () => {
+      const userModeServer = {
+        type: "stdio",
+        command: "mcpadre",
+        args: ["run", "--user", "my-server"],
+      };
+
+      expect(extractMcpadreServerName(userModeServer, "stdio")).toBe(
+        "my-server"
+      );
+    });
+
+    it("extracts server name from zed format with --user flag", () => {
+      const userModeServer = {
+        command: {
+          path: "mcpadre",
+          args: ["run", "--user", "my-server"],
+        },
+      };
+
+      expect(extractMcpadreServerName(userModeServer, "zed")).toBe("my-server");
+    });
+
+    it("extracts server name from opencode format", () => {
+      const server = {
+        type: "local",
+        command: ["mcpadre", "run", "my-server"],
+        enabled: true,
+      };
+
+      expect(extractMcpadreServerName(server, "opencode")).toBe("my-server");
+    });
+
+    it("extracts server name from opencode format with --user flag", () => {
+      const userModeServer = {
+        type: "local",
+        command: ["mcpadre", "run", "--user", "my-server"],
+        enabled: true,
+      };
+
+      expect(extractMcpadreServerName(userModeServer, "opencode")).toBe(
+        "my-server"
+      );
+    });
+
+    it("returns null for malformed --user entries", () => {
+      const malformedServer = {
+        command: "mcpadre",
+        args: ["run", "--user"], // Missing server name after --user
+      };
+
+      expect(extractMcpadreServerName(malformedServer, "simple")).toBe(null);
+    });
   });
 
   describe("classifyServers", () => {

--- a/packages/cli/src/installer/discovery/server-detector.ts
+++ b/packages/cli/src/installer/discovery/server-detector.ts
@@ -121,27 +121,57 @@ export function extractMcpadreServerName(
 
   switch (hostFormat) {
     case "simple":
-    case "stdio":
-      // args: ["run", "serverName"]
-      return Array.isArray(serverEntry["args"]) &&
-        serverEntry["args"].length >= 2
-        ? String(serverEntry["args"][1])
-        : null;
+    case "stdio": {
+      // Handle both project mode: ["run", "serverName"]
+      // and user mode: ["run", "--user", "serverName"]
+      const args = serverEntry["args"];
+      if (!Array.isArray(args) || args.length < 2) {
+        return null;
+      }
 
-    case "zed": {
-      // command.args: ["run", "serverName"]
-      const command = serverEntry["command"] as Record<string, unknown>;
-      return Array.isArray(command["args"]) && command["args"].length >= 2
-        ? String(command["args"][1])
-        : null;
+      if (args[1] === "--user") {
+        // User mode: must have serverName at position 2
+        return args.length >= 3 ? String(args[2]) : null;
+      } else {
+        // Project mode: serverName at position 1
+        return String(args[1]);
+      }
     }
 
-    case "opencode":
-      // command: ["mcpadre", "run", "serverName"]
-      return Array.isArray(serverEntry["command"]) &&
-        serverEntry["command"].length >= 3
-        ? String(serverEntry["command"][2])
-        : null;
+    case "zed": {
+      // Handle both project mode: ["run", "serverName"]
+      // and user mode: ["run", "--user", "serverName"]
+      const command = serverEntry["command"] as Record<string, unknown>;
+      const args = command["args"];
+      if (!Array.isArray(args) || args.length < 2) {
+        return null;
+      }
+
+      if (args[1] === "--user") {
+        // User mode: must have serverName at position 2
+        return args.length >= 3 ? String(args[2]) : null;
+      } else {
+        // Project mode: serverName at position 1
+        return String(args[1]);
+      }
+    }
+
+    case "opencode": {
+      // Handle both project mode: ["mcpadre", "run", "serverName"]
+      // and user mode: ["mcpadre", "run", "--user", "serverName"]
+      const command = serverEntry["command"];
+      if (!Array.isArray(command) || command.length < 3) {
+        return null;
+      }
+
+      if (command[2] === "--user") {
+        // User mode: must have serverName at position 3
+        return command.length >= 4 ? String(command[3]) : null;
+      } else {
+        // Project mode: serverName at position 2
+        return String(command[2]);
+      }
+    }
 
     default:
       return null;

--- a/packages/cli/src/integration-tests/cli/user-install-orphaned-bug.integration.test.ts
+++ b/packages/cli/src/integration-tests/cli/user-install-orphaned-bug.integration.test.ts
@@ -1,0 +1,192 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { type SpawnFunction, withProcess } from "../helpers/spawn-cli-v2.js";
+
+describe("User Install Orphaned Server Bug", () => {
+  let tempDir: string;
+  let userConfigDir: string;
+  let userConfigPath: string;
+  let fakeHomeDir: string;
+  let claudeConfigPath: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "mcpadre-test-orphaned-")
+    );
+    userConfigDir = path.join(tempDir, ".mcpadre");
+    userConfigPath = path.join(userConfigDir, "mcpadre.yaml");
+    fakeHomeDir = path.join(tempDir, "fake-home");
+    claudeConfigPath = path.join(fakeHomeDir, ".claude.json");
+
+    // Create user config directory and fake home directory
+    await fs.promises.mkdir(userConfigDir, { recursive: true });
+    await fs.promises.mkdir(fakeHomeDir, { recursive: true });
+
+    // Create user config with test servers (using node only for test environment)
+    const userConfig = `
+version: 1
+mcpServers:
+  test-server-1:
+    node:
+      package: "@modelcontextprotocol/server-memory"
+      version: "0.6.0"
+  test-server-2:
+    node:
+      package: "@modelcontextprotocol/server-filesystem"
+      version: "0.6.0"
+hosts:
+  claude-code: true
+`;
+    await fs.promises.writeFile(userConfigPath, userConfig, "utf8");
+  });
+
+  afterEach(async () => {
+    if (tempDir) {
+      await fs.promises.rm(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it(
+    "should not report servers as orphaned on second install run",
+    withProcess(async (spawn: SpawnFunction) => {
+      // First install - should succeed without issues
+      const firstResult = await spawn(["install", "--user"], {
+        cwd: tempDir,
+        buffer: true,
+        env: {
+          ...process.env,
+          MCPADRE_USER_DIR: userConfigDir,
+          HOME: fakeHomeDir,
+        },
+      });
+
+      expect(firstResult.exitCode).toBe(0);
+      expect(firstResult.stderr).toContain(
+        "Installed for 1 host(s): claude-code"
+      );
+      expect(firstResult.stderr).toContain(
+        "Configured 2 server(s) across all hosts"
+      );
+
+      // Verify the Claude Code config was created with --user flag entries
+      expect(fs.existsSync(claudeConfigPath)).toBe(true);
+      const claudeConfig = JSON.parse(
+        await fs.promises.readFile(claudeConfigPath, "utf8")
+      );
+
+      // Check that both servers are in the config with --user flag
+      expect(claudeConfig.mcpServers["test-server-1"]).toBeDefined();
+      expect(claudeConfig.mcpServers["test-server-1"].args).toEqual([
+        "run",
+        "--user",
+        "test-server-1",
+      ]);
+      expect(claudeConfig.mcpServers["test-server-2"]).toBeDefined();
+      expect(claudeConfig.mcpServers["test-server-2"].args).toEqual([
+        "run",
+        "--user",
+        "test-server-2",
+      ]);
+
+      // Second install - should NOT report orphaned servers
+      const secondResult = await spawn(["install", "--user"], {
+        cwd: tempDir,
+        buffer: true,
+        env: {
+          ...process.env,
+          MCPADRE_USER_DIR: userConfigDir,
+          HOME: fakeHomeDir,
+        },
+      });
+
+      expect(secondResult.exitCode).toBe(0);
+
+      // BUG: Currently this fails because servers are incorrectly detected as orphaned
+      // The system extracts "--user" as the server name instead of the actual server name
+      // This should NOT contain any "orphaned" warnings
+      expect(secondResult.stdout).not.toContain("orphaned");
+      expect(secondResult.stderr).not.toContain("orphaned");
+
+      // Should still show the same success metrics
+      expect(secondResult.stderr).toContain(
+        "Installed for 1 host(s): claude-code"
+      );
+      expect(secondResult.stderr).toContain(
+        "Configured 2 server(s) across all hosts"
+      );
+
+      // Verify servers are still in the config and not removed
+      const finalClaudeConfig = JSON.parse(
+        await fs.promises.readFile(claudeConfigPath, "utf8")
+      );
+      expect(finalClaudeConfig.mcpServers["test-server-1"]).toBeDefined();
+      expect(finalClaudeConfig.mcpServers["test-server-2"]).toBeDefined();
+    })
+  );
+
+  it(
+    "should correctly identify actual orphaned servers when they are removed from config",
+    withProcess(async (spawn: SpawnFunction) => {
+      // First install with both servers
+      await spawn(["install", "--user"], {
+        cwd: tempDir,
+        buffer: true,
+        env: {
+          ...process.env,
+          MCPADRE_USER_DIR: userConfigDir,
+          HOME: fakeHomeDir,
+        },
+      });
+
+      // Remove one server from mcpadre.yaml
+      const updatedConfig = `
+version: 1
+mcpServers:
+  test-server-1:
+    node:
+      package: "@modelcontextprotocol/server-memory"
+      version: "0.6.0"
+  # test-server-2 removed
+hosts:
+  claude-code: true
+`;
+      await fs.promises.writeFile(userConfigPath, updatedConfig, "utf8");
+
+      // Second install - should detect test-server-2 as actually orphaned
+      const result = await spawn(["install", "--user"], {
+        cwd: tempDir,
+        buffer: true,
+        env: {
+          ...process.env,
+          MCPADRE_USER_DIR: userConfigDir,
+          HOME: fakeHomeDir,
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Should correctly identify only test-server-2 as orphaned
+      expect(result.stderr).toContain(
+        "Removing orphaned mcpadre server 'test-server-2'"
+      );
+      expect(result.stderr).not.toContain(
+        "Removing orphaned mcpadre server 'test-server-1'"
+      );
+
+      // Should show cleanup was performed
+      expect(result.stderr).toContain(
+        "Cleaned up 1 orphaned mcpadre server(s)"
+      );
+
+      // Verify test-server-1 is still there, test-server-2 is removed
+      const finalClaudeConfig = JSON.parse(
+        await fs.promises.readFile(claudeConfigPath, "utf8")
+      );
+      expect(finalClaudeConfig.mcpServers["test-server-1"]).toBeDefined();
+      expect(finalClaudeConfig.mcpServers["test-server-2"]).toBeUndefined();
+    })
+  );
+});


### PR DESCRIPTION
## Description

Fixes a bug where running `mcpadre install --user` multiple times would incorrectly report legitimate servers as "orphaned" and remove them from host configuration files. The issue was in the server name extraction logic that was extracting `"--user"` instead of the actual server name from user-mode entries like `["run", "--user", "server-name"]`.

## Related Issues

- Fixes user-reported issue where `mcpadre install --user` shows false orphaned warnings on subsequent runs
- Addresses server removal bug in user-mode installations

## Changes

- **Core Fix**: Updated `extractMcpadreServerName()` in `src/installer/discovery/server-detector.ts` to properly handle the `--user` flag for all host formats (simple, stdio, zed, opencode)
- **Unit Tests**: Added 6 comprehensive unit tests covering `--user` flag scenarios for all host configuration formats
- **Integration Test**: Created end-to-end test (`user-install-orphaned-bug.integration.test.ts`) that reproduces the exact user scenario and validates the fix
- **Backward Compatibility**: Maintained full compatibility with existing project-mode server entries

## Testing

- [x] **Integration tests run locally and pass** (required - integration tests don't run in CI yet)
- [x] Unit tests pass (`pnpm test`) - All 534 unit tests passing
- [x] Type checking passes (`pnpm typecheck`)
- [x] Linting passes (`pnpm lint`)

### Test Coverage

**Unit Tests (6 new tests):**
- `extractMcpadreServerName()` with `--user` flag for simple format
- `extractMcpadreServerName()` with `--user` flag for stdio format
- `extractMcpadreServerName()` with `--user` flag for zed format
- `extractMcpadreServerName()` with `--user` flag for opencode format
- Basic opencode format extraction (added missing test)
- Malformed `--user` entries (error handling)

**Integration Tests (1 new test suite):**
- End-to-end test reproducing the bug scenario:
  1. First `mcpadre install --user` run (should succeed)
  2. Second `mcpadre install --user` run (should NOT show orphaned warnings)
  3. Actual orphaned server detection (should still work correctly)

**Regression Testing:**
- All existing 268 integration tests pass
- All existing 534 unit tests pass

## Additional Notes

**Before Fix:**
```
$ mcpadre install --user
> Installing configuration for enabled hosts in user mode...
> Installed for 1 host(s): claude-code
> Configured 2 server(s) across all hosts

$ mcpadre install --user
W Removing orphaned mcpadre server 'brave-search-mcp-server' from ~/.claude.json (no longer in mcpadre.yaml)
W Removing orphaned mcpadre server 'mcp-sleep' from ~/.claude.json (no longer in mcpadre.yaml)
> Cleaned up 2 orphaned mcpadre server(s) from host configs
```

**After Fix:**
```
$ mcpadre install --user
> Installing configuration for enabled hosts in user mode...
> Installed for 1 host(s): claude-code
> Configured 2 server(s) across all hosts

$ mcpadre install --user
> Installing configuration for enabled hosts in user mode...
> Installed for 1 host(s): claude-code
> Configured 2 server(s) across all hosts
```

**Edge Cases Handled:**
- Maintains project-mode compatibility (`["run", "server-name"]`)
- Handles user-mode entries (`["run", "--user", "server-name"]`)
- Proper error handling for malformed entries (`["run", "--user"]` without server name)
- Works across all host formats (Claude Code, Claude Desktop, Cursor, OpenCode, Zed)

**No Breaking Changes:** This is a pure bug fix that doesn't change any APIs or user-facing behavior, only corrects incorrect detection logic.